### PR TITLE
Feat: added more arguments to `generator.license.rb`

### DIFF
--- a/src/generator.license.rb
+++ b/src/generator.license.rb
@@ -37,27 +37,27 @@ OptionParser.new do |opts|
     license_json_path = File.expand_path(v)
   end
 
-  opts.on("--license-name <Name>", "Specify license name (optional) [#{license_name}]") do |v|
+  opts.on("--license-name NAME", "Specify license name (optional) [#{license_name}]") do |v|
     license_name = v
   end
 
-  opts.on("--license-company <Company Name>", "Specify license company (optional) [#{license_company}]") do |v|
+  opts.on("--license-company COMPANY", "Specify license company (optional) [#{license_company}]") do |v|
     license_company = v
   end
 
-  opts.on("--license-email <Email Address>", "Specify license email address (optional) [#{license_email}]") do |v|
+  opts.on("--license-email EMAIL-ADDRESS", "Specify license email address (optional) [#{license_email}]") do |v|
     license_email = v
   end
   
-  opts.on("--license-plan <Plan>", "Specify license plan (optional) [#{license_plan}(default),premium,starter]") do |v|
+  opts.on("--license-plan PLAN", "Specify license plan (optional) [#{license_plan}(default),premium,starter]") do |v|
     license_plan = v
   end
   
-  opts.on("--license-user-count <Email Address>", "Specify license user count (optional) [#{license_user_count}(default)]") do |v|
+  opts.on("--license-user-count COUNT", "Specify license user count (optional) [#{license_user_count}(default)]") do |v|
     license_user_count = v.to_i
   end
   
-  opts.on("--license-expire-year <Year>", "Specify license expire year (optional) [#{license_expire_year}(default)]") do |v|
+  opts.on("--license-expire-year YEAR", "Specify license expire year (optional) [#{license_expire_year}(default)]") do |v|
     license_expire_year = v.to_i
   end
   

--- a/src/generator.license.rb
+++ b/src/generator.license.rb
@@ -49,15 +49,15 @@ OptionParser.new do |opts|
     license_email = v
   end
   
-  opts.on("--license-plan PLAN", "Specify license plan (optional) [#{license_plan}(default),premium,starter]") do |v|
+  opts.on("--license-plan PLAN", "Specify license plan (optional) [#{license_plan} (default), premium, starter]") do |v|
     license_plan = v
   end
   
-  opts.on("--license-user-count COUNT", "Specify license user count (optional) [#{license_user_count}(default)]") do |v|
+  opts.on("--license-user-count COUNT", "Specify license user count (optional) [#{license_user_count} (default)]") do |v|
     license_user_count = v.to_i
   end
   
-  opts.on("--license-expire-year YEAR", "Specify license expire year (optional) [#{license_expire_year}(default)]") do |v|
+  opts.on("--license-expire-year YEAR", "Specify license expire year (optional) [#{license_expire_year} (default)]") do |v|
     license_expire_year = v.to_i
   end
   

--- a/src/generator.license.rb
+++ b/src/generator.license.rb
@@ -6,6 +6,12 @@ license_json_path = nil
 public_key_path = nil
 private_key_path = nil
 features_json_path = nil
+license_name="Tim Cook"
+license_company="Apple Computer, Inc."
+license_email="tcook@apple.com"
+license_plan='ultimate'
+license_user_count=2147483647
+license_expire_year=2500
 
 require 'optparse'
 OptionParser.new do |opts|
@@ -31,6 +37,30 @@ OptionParser.new do |opts|
     license_json_path = File.expand_path(v)
   end
 
+  opts.on("--license-name <Name>", "Specify license name (optional) [#{license_name}]") do |v|
+    license_name = v
+  end
+
+  opts.on("--license-company <Company Name>", "Specify license company (optional) [#{license_company}]") do |v|
+    license_company = v
+  end
+
+  opts.on("--license-email <Email Address>", "Specify license email address (optional) [#{license_email}]") do |v|
+    license_email = v
+  end
+  
+  opts.on("--license-plan <Plan>", "Specify license plan (optional) [#{license_plan}(default),premium,starter]") do |v|
+    license_plan = v
+  end
+  
+  opts.on("--license-user-count <Email Address>", "Specify license user count (optional) [#{license_user_count}(default)]") do |v|
+    license_user_count = v.to_i
+  end
+  
+  opts.on("--license-expire-year <Year>", "Specify license expire year (optional) [#{license_expire_year}(default)]") do |v|
+    license_expire_year = v.to_i
+  end
+  
   opts.on("-h", "--help", "Prints this help") do
       puts opts
       exit
@@ -44,6 +74,11 @@ if license_file_path.nil? || public_key_path.nil? || private_key_path.nil?
   exit 1
 end
 
+if license_plan != 'ultimate' &&  license_plan != 'premium' &&  license_plan != 'starter' &&
+  puts "[!] license plan is set to #{license_plan} which is not one of [ultimate, premium, starter]"
+  puts "[!] use -h for help"
+  exit 1
+end
 # ==========
 
 puts "[*] loading keys..."
@@ -74,29 +109,29 @@ license = Gitlab::License.new
 
 # don't use gitlab inc, search `gl_team_license` in lib for details
 license.licensee = {
-  "Name"    => "Tim Cook",
-  "Company" => "Apple Computer, Inc.",
-  "Email"   => "tcook@apple.com"
+  "Name"    => license_name,
+  "Company" => license_company,
+  "Email"   => license_email
 }
 
 # required of course
 license.starts_at         = Date.new(1976, 4, 1)
 
 # required since gem gitlab-license v2.2.1
-license.expires_at        = Date.new(2500, 4, 1)
+license.expires_at        = Date.new(license_expire_year, 4, 1)
 
 # prevent gitlab crash at
 # notification_start_date = trial? ? expires_at - NOTIFICATION_DAYS_BEFORE_TRIAL_EXPIRY : block_changes_at
-license.block_changes_at  = Date.new(2500, 4, 1)
+license.block_changes_at  = Date.new(license_expire_year, 4, 1)
 
 # required
 license.restrictions      = {
-  plan: 'ultimate',
+  plan: license_plan,
   # STARTER_PLAN = 'starter'
   # PREMIUM_PLAN = 'premium'
   # ULTIMATE_PLAN = 'ultimate'
 
-  active_user_count: 2147483647,
+  active_user_count: license_user_count,
   # required, just dont overflow
 }
 
@@ -105,7 +140,7 @@ license.restrictions      = {
 # so here by we inject all features into restrictions
 # see scan.rb for a list of features that we are going to inject
 for feature in FEATURE_LIST
-  license.restrictions[feature] = 2147483647
+  license.restrictions[feature] = license_user_count
 end
 
 puts "[*] validating license..."

--- a/src/generator.license.rb
+++ b/src/generator.license.rb
@@ -48,19 +48,19 @@ OptionParser.new do |opts|
   opts.on("--license-email EMAIL-ADDRESS", "Specify license email address (optional) [#{license_email}]") do |v|
     license_email = v
   end
-  
+
   opts.on("--license-plan PLAN", "Specify license plan (optional) [#{license_plan} (default), premium, starter]") do |v|
     license_plan = v
   end
-  
+
   opts.on("--license-user-count COUNT", "Specify license user count (optional) [#{license_user_count} (default)]") do |v|
     license_user_count = v.to_i
   end
-  
+
   opts.on("--license-expire-year YEAR", "Specify license expire year (optional) [#{license_expire_year} (default)]") do |v|
     license_expire_year = v.to_i
   end
-  
+
   opts.on("-h", "--help", "Prints this help") do
       puts opts
       exit
@@ -79,6 +79,19 @@ if license_plan != 'ultimate' &&  license_plan != 'premium' &&  license_plan != 
   puts "[!] use -h for help"
   exit 1
 end
+
+if Time.now.year > license_expire_year
+  puts "[!] license expiry year is set to #{license_expire_year} which is less than current year, this value must be greater than current year"
+  puts "[!] use -h for help"
+  exit 1
+end
+
+if license_user_count < 1
+  puts "[!] license user count is set to #{license_user_count} which is less minumum user count possible"
+  puts "[!] use -h for help"
+  exit 1
+end
+
 # ==========
 
 puts "[*] loading keys..."
@@ -94,7 +107,7 @@ if !features_json_path.nil?
   puts "[*] loading features from #{features_json_path}"
   require 'json'
   FEATURE_LIST = JSON.parse(File.read(features_json_path))
-else 
+else
   FEATURE_LIST = []
 end
 puts "[*] total features to inject: #{FEATURE_LIST.size}"
@@ -116,7 +129,7 @@ license.licensee = {
 
 # required of course
 license.starts_at         = Date.new(1976, 4, 1)
-
+puts Date.new()
 # required since gem gitlab-license v2.2.1
 license.expires_at        = Date.new(license_expire_year, 4, 1)
 

--- a/src/generator.license.rb
+++ b/src/generator.license.rb
@@ -74,7 +74,7 @@ if license_file_path.nil? || public_key_path.nil? || private_key_path.nil?
   exit 1
 end
 
-if license_plan != 'ultimate' &&  license_plan != 'premium' &&  license_plan != 'starter' &&
+if license_plan != 'ultimate' &&  license_plan != 'premium' &&  license_plan != 'starter'
   puts "[!] license plan is set to #{license_plan} which is not one of [ultimate, premium, starter]"
   puts "[!] use -h for help"
   exit 1


### PR DESCRIPTION
Added flags:
* `--license-name`: defaults to `Tim Cook`
* `--license-company`: defaults to `Apple Computer, Inc.`
* `--license-email `: defaults to `tcook@apple.com`
* `--license-plan`: defaults to `ultimate`, accepted values are `ultimate`, `premium`, `starter`
* `--license-user-count`: defaults to `2147483647`
* `--expire-year`: defaults to `2500`
